### PR TITLE
Configure postgres for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ ruby '2.6.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.6'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use postgres in production (sqlite3 still used for dev and test)
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
@@ -45,6 +45,7 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'sqlite3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
@@ -54,6 +55,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
+  gem 'sqlite3'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.3-x86_64-linux)
       racc (~> 1.4)
+    pg (1.2.3)
     public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)
@@ -195,6 +196,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.11)
   rails (~> 5.2.6)
   sass-rails (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You might use collection_radio_buttons where you are collecting votes for
 multiple things, for example if you have a review site like goodreads or 
 TripAdvisor.
 
+You can see a live demo at https://multiple-radio-buttons.herokuapp.com/
+
 ## Get started
 
 * Setup sqlite

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,11 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  schema_search_path: "public"
+  database: db/multiple.pg


### PR DESCRIPTION
Configure postgres for production, mainly because heroku only supports pg, not sqlite or mysql.

Code changes:

* add pg gem
* configure pg for production (only)

Non-code changes, from heroku cli I also ran the following:

* db:schema:load
* db:seed

This code now up and running at https://multiple-radio-buttons.herokuapp.com/
